### PR TITLE
Fix assigning effectSobel variable

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1075,6 +1075,7 @@ export class BodyEditor {
         effectSobel.uniforms['resolution'].value.y =
             this.Height * window.devicePixelRatio
         this.composer.addPass(effectSobel)
+        this.effectSobel = effectSobel
     }
 
     changeComposerResoultion(width: number, height: number) {


### PR DESCRIPTION
Assign `effectSobel` after it has been created to fix the problem of images not being output correctly in some cases.