### PR TITLE
Support for changing the position and size of canvas

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -503,15 +503,12 @@ export class BodyEditor {
     }
 
     onMouseDown(event: MouseEvent) {
+        const x = event.offsetX - this.renderer.domElement.offsetLeft
+        const y = event.offsetY - this.renderer.domElement.offsetTop
         this.raycaster.setFromCamera(
             {
-                x:
-                    (event.clientX / this.renderer.domElement.clientWidth) * 2 -
-                    1,
-                y:
-                    -(event.clientY / this.renderer.domElement.clientHeight) *
-                        2 +
-                    1,
+                x: (x / this.renderer.domElement.clientWidth) * 2 - 1,
+                y: -(y / this.renderer.domElement.clientHeight) * 2 + 1,
             },
             this.camera
         )
@@ -1045,6 +1042,7 @@ export class BodyEditor {
         if (size.width == this.Width && size.height === this.Height) return
 
         const canvas = this.renderer.domElement
+        if (canvas.clientWidth == 0 || canvas.clientHeight == 0) return
         this.camera.aspect = canvas.clientWidth / canvas.clientHeight
 
         this.camera.updateProjectionMatrix()


### PR DESCRIPTION
For a1111 extension, support for changing the position and size of the canvas.
* Change `onMouseDown` to calculate relative mouse position
* Change `handleResize` to avoid division by zero in aspect calculation when canvas is hidden