### PR TITLE
Fix targets position after loading scene

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1317,6 +1317,9 @@ export class BodyEditor {
             this.ClearScene()
 
             if (bodiesObject.length > 0) this.scene.add(...bodiesObject)
+            for (const body of bodiesObject) {
+                new BodyControlor(body).ResetAllTargetsPosition()
+            }
             this.RestoreCamera(camera)
         } catch (error: any) {
             Oops(error)


### PR DESCRIPTION
Fix targets position after loading scene.

# Steps to reproduce

1. Open 3D Openpose Editor
2. Set random pose
3. Save scene to json file
4. Set random pose
5. Load scene from json file

The targets position is wrong as follows.

![image](https://user-images.githubusercontent.com/42905588/227160815-752594ae-38bf-48a1-b5e7-54da558061b0.png)
