### PR TITLE
Fix a problem that the view cannot be unfixed even after restoring

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1398,7 +1398,10 @@ export class BodyEditor {
         this.cameraDataOfView = this.GetCameraData()
     }
     RestoreView() {
-        if (this.cameraDataOfView) this.RestoreCamera(this.cameraDataOfView)
+        if (this.cameraDataOfView) {
+            this.RestoreCamera(this.cameraDataOfView)
+            this.cameraDataOfView = undefined
+        }
     }
 
     changeView() {


### PR DESCRIPTION
Related to https://github.com/nonnonstop/sd-webui-3d-open-pose-editor/issues/31
Fix a problem that the view cannot be unfixed even after restoring.