### PR TITLE
Load scenes from URL hash

### DIFF
--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -12,6 +12,7 @@ import useForceUpdate from '../../hooks/useFoceUpdate'
 import classNames from 'classnames'
 import { useLanguageSelect } from '../../hooks'
 import { ShowContextMenu } from '../ContextMenu'
+import { ShowDialog } from '../Dialog'
 
 const {
     MenubarRoot,
@@ -70,6 +71,19 @@ const MenubarDemo: React.FC<{
                             onSelect={() => editor.SaveScene()}
                         >
                             {i18n.t('Save Scene')}
+                        </Menubar.Item>
+                        <Menubar.Item
+                            className={MenubarItem}
+                            onSelect={() => {
+                                const url = editor.GenerateSceneURL()
+                                ShowDialog({
+                                    title: 'URL',
+                                    description: url,
+                                    button: 'OK',
+                                })
+                            }}
+                        >
+                            {i18n.t('Generate Scene URL')}
                         </Menubar.Item>
                         <Menubar.Separator className={MenubarSeparator} />
                         <Menubar.Item

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1397,6 +1397,17 @@ export class BodyEditor {
         }
     }
 
+    GenerateSceneURL() {
+        try {
+            const d = encodeURIComponent(JSON.stringify(this.GetSceneData()))
+            const url_base = location.href.replace(/#$/, '')
+            return `${url_base}#${d}`
+        } catch (error) {
+            console.error(error)
+        }
+        return null
+    }
+
     ClearScene() {
         this.scene.children
             .filter((o) => o?.name === 'torso')

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -41,6 +41,13 @@ export function useBodyEditor(
             if (editor) {
                 await LoadBodyData()
                 editor?.InitScene()
+                if (editor?.RestoreScene && location.hash) {
+                    const rawData = decodeURIComponent(
+                        location.hash.replace(/^#/, '')
+                    )
+                    editor?.RestoreScene(rawData)
+                    location.hash = ''
+                }
             }
         }
         init()

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,6 +16,7 @@
     "Something went wrong!": "Something went wrong!",
     "If the problem persists, please click here to ask a question.": "If the problem persists, please click here to ask a question.",
     "Save Scene": "Save Scene",
+    "Generate Scene URL": "Generate Scene URL",
     "Load Scene": "Load Scene",
     "Restore Last Scene": "Restore Last Scene",
     "Set Background Image": "Set Background Image",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -16,6 +16,7 @@
     "Something went wrong!": "何かが間違っています！",
     "If the problem persists, please click here to ask a question.": "問題が解決しない場合は、ここをクリックして質問してください。",
     "Save Scene": "シーンを保存",
+    "Generate Scene URL": "シーンのURLを生成",
     "Load Scene": "シーンを読み込む",
     "Restore Last Scene": "前回のシーンを復元",
     "Set Background Image": "背景画像を設定",


### PR DESCRIPTION
To share the current scene, we need to generate a JSON file and have it downloaded and loaded.
The purpose of this pull request is to easily share scenes via URL like the following format.

```
https://zhuyu1997.github.io/open-pose-editor/#xxxxxx
```

This makes it easier and more convenient to integrate with other web applications.
## format description

``xxxxxx`` is URI encoded JSON scene data.

For example:

```json
{"header":"Openpose Editor by Yu Zhu","version":"0.1.5","object":{"bodies":[{"position":[0,49.39 ....
```

URI encoded JSON:

```txt
%7B%22header%22%3A%22Openpose%20Editor%20by%20Yu%20Zhu%22....
```

which is generated by ``encodeURIComponent('{"header":"Openpose Editor by Yu Zhu","ver.....')``